### PR TITLE
fix(etcd): resp.Kvs could be []KeyValue{nil} when Get is NotFound

### DIFF
--- a/pkg/aggregator/spancache/etcd/etcd.go
+++ b/pkg/aggregator/spancache/etcd/etcd.go
@@ -179,7 +179,7 @@ func (cache *Etcd) Fetch(ctx context.Context, key string) (*spancache.Entry, err
 		return nil, fmt.Errorf("etcd request error: %w", err)
 	}
 
-	if len(resp.Kvs) == 0 {
+	if len(resp.Kvs) == 0 || resp.Kvs[0] == nil {
 		return nil, nil
 	}
 
@@ -239,7 +239,7 @@ func (cache *Etcd) SetReserved(ctx context.Context, key string, value []byte, la
 
 	getResp := resp.Responses[0].GetResponseRange()
 
-	if len(getResp.Kvs) == 0 {
+	if len(getResp.Kvs) == 0 || getResp.Kvs[0] == nil {
 		return spancache.ErrInvalidKey
 	}
 

--- a/pkg/diff/cache/etcd/etcd.go
+++ b/pkg/diff/cache/etcd/etcd.go
@@ -152,7 +152,7 @@ func (cache *Etcd) Fetch(
 		return nil, metrics.LabelError(err, "UnknownEtcd")
 	}
 
-	if len(resp.Kvs) == 0 {
+	if len(resp.Kvs) == 0 || resp.Kvs[0] == nil {
 		return nil, nil
 	}
 
@@ -195,7 +195,7 @@ func (cache *Etcd) FetchSnapshot(ctx context.Context, object util.ObjectRef, sna
 		return nil, metrics.LabelError(err, "UnknownEtcd")
 	}
 
-	if len(resp.Kvs) == 0 {
+	if len(resp.Kvs) == 0 || resp.Kvs[0] == nil {
 		return nil, nil
 	}
 

--- a/pkg/frontend/tracecache/etcd/etcd.go
+++ b/pkg/frontend/tracecache/etcd/etcd.go
@@ -121,12 +121,13 @@ func (cache *etcdCache) Persist(ctx context.Context, entries []tracecache.Entry)
 }
 
 func (cache *etcdCache) Fetch(ctx context.Context, lowId uint64) (json.RawMessage, error) {
+	cache.logger.Warn(cache.cacheKey(lowId))
 	resp, err := cache.client.Get(ctx, cache.cacheKey(lowId))
 	if err != nil {
 		return nil, fmt.Errorf("etcd get error: %w", err)
 	}
 
-	if len(resp.Kvs) == 0 {
+	if len(resp.Kvs) == 0 || resp.Kvs[0] == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

Handle the NotFound case for etcd cache backends properly.

An example dump of a NotFound output:

```go
&clientv3.GetResponse{Header:(*etcdserverpb.ResponseHeader)(0xc042675540), Kvs:[]*mvccpb.KeyValue(nil), More:false, Count:0, XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}
```

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
