### PR TITLE
chore: `--no-build` in `make quickstart` does not work on fresh builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ kind:
 COMPOSE_COMMAND ?= up --build -d --remove-orphans
 
 stack:
-	docker-compose -f dev.docker-compose.yaml up --no-recreate --no-build --no-start # create network only
+	docker-compose -f dev.docker-compose.yaml up --no-recreate --no-start # create network only
 	docker-compose \
 		-f dev.docker-compose.yaml \
 		-f <(jq -n \
@@ -148,7 +148,7 @@ stack:
 		$(COMPOSE_COMMAND)
 
 quickstart:
-	docker-compose -f quickstart.docker-compose.yaml up --no-recreate --no-build --no-start
+	docker-compose -f quickstart.docker-compose.yaml up --no-recreate --no-start
 	kubectl config view --raw --minify --flatten --merge >hack/client-kubeconfig.local.yaml
 	sed -i "s/0\.0\.0\.0/$$(docker network inspect kelemetry_default -f '{{(index .IPAM.Config 0).Gateway}}')/g" hack/client-kubeconfig.local.yaml
 	sed -i 's/certificate-authority-data: .*$$/insecure-skip-tls-verify: true/' hack/client-kubeconfig.local.yaml


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

When trying to run quickstart on a new repo, I get this error:
```console
$ make quickstart 
docker-compose -f quickstart.docker-compose.yaml up --no-recreate --no-build --no-start
Creating network "kelemetry_default" with the default driver
Creating volume "kelemetry_etcd" with default driver
Creating volume "kelemetry_es" with default driver
Pulling etcd (quay.io/coreos/etcd:v3.2)...
Pulling es (docker.elastic.co/elasticsearch/elasticsearch:7.17.9)...
Pulling jaeger-query (jaegertracing/jaeger-query:1.42)...
Pulling jaeger-collector (jaegertracing/jaeger-collector:1.42)...
ERROR: Service 'kelemetry' needs to be built, but --no-build was passed.
make: *** [Makefile:151: quickstart] Error 1
```

The `--no-build` there did not really make sense anyway, since the dry-run for network creation is not affected by building anyway

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
