### PR TITLE
feat(event/tag): add custom tag for resource and build trace link for…

### DIFF
--- a/pkg/aggregator/aggregatorevent/event.go
+++ b/pkg/aggregator/aggregatorevent/event.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aggregator
+package aggregatorevent
 
 import (
 	"time"
@@ -42,7 +42,7 @@ func NewEvent(field string, title string, when time.Time, traceSource string) *E
 	}
 }
 
-func (event *Event) getEndTime() time.Time {
+func (event *Event) GetEndTime() time.Time {
 	if event.EndTime != nil {
 		return *event.EndTime
 	}

--- a/pkg/aggregator/eventdecorator/decorator.go
+++ b/pkg/aggregator/eventdecorator/decorator.go
@@ -12,40 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit
+package eventdecorator
 
 import (
+	"context"
+
 	"github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
 	"github.com/kubewharf/kelemetry/pkg/manager"
+	"github.com/kubewharf/kelemetry/pkg/util"
 )
 
 func init() {
-	manager.Global.Provide("audit-decorator-list", manager.Ptr[DecoratorList](&decoratorList{}))
+	manager.Global.Provide("event-union-decorator", manager.Ptr[UnionEventDecorator](&unionDecorator{}))
 }
 
 type Decorator interface {
-	Decorate(message *Message, event *aggregatorevent.Event)
+	Decorate(ctx context.Context, object util.ObjectRef, event *aggregatorevent.Event)
 }
 
-type DecoratorList interface {
+type UnionEventDecorator interface {
 	manager.Component
 
 	AddDecorator(decorator Decorator)
 
-	Decorate(message *Message, event *aggregatorevent.Event)
+	Decorate(ctx context.Context, object util.ObjectRef, event *aggregatorevent.Event)
 }
 
-type decoratorList struct {
+type unionDecorator struct {
 	manager.BaseComponent
 	decorators []Decorator
 }
 
-func (list *decoratorList) AddDecorator(decorator Decorator) {
-	list.decorators = append(list.decorators, decorator)
+func NewUnionDecorator() UnionEventDecorator {
+	return &unionDecorator{
+		decorators: []Decorator{},
+	}
 }
 
-func (list *decoratorList) Decorate(message *Message, event *aggregatorevent.Event) {
-	for _, decorator := range list.decorators {
-		decorator.Decorate(message, event)
+func (union *unionDecorator) AddDecorator(decorator Decorator) {
+	union.decorators = append(union.decorators, decorator)
+}
+
+func (union *unionDecorator) Decorate(ctx context.Context, object util.ObjectRef, event *aggregatorevent.Event) {
+	for _, decorator := range union.decorators {
+		decorator.Decorate(ctx, object, event)
 	}
 }

--- a/pkg/aggregator/eventdecorator/tag/resource_tag.go
+++ b/pkg/aggregator/eventdecorator/tag/resource_tag.go
@@ -1,0 +1,178 @@
+// Copyright 2023 The Kelemetry Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/jsonpath"
+
+	"github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
+	"github.com/kubewharf/kelemetry/pkg/aggregator/eventdecorator"
+	"github.com/kubewharf/kelemetry/pkg/k8s/objectcache"
+	"github.com/kubewharf/kelemetry/pkg/manager"
+	"github.com/kubewharf/kelemetry/pkg/util"
+)
+
+func init() {
+	manager.Global.Provide("resource-tagger", manager.Ptr(&tagDecorator{}))
+}
+
+var defaultTagMapping = []string{"pods#nodes:spec.nodeName"}
+
+type options struct {
+	enable              bool
+	resourceTagMappings []string
+}
+
+func (options *options) Setup(fs *pflag.FlagSet) {
+	fs.BoolVar(&options.enable, "resource-custom-tag-enable", false, "enable custom event tag for resource")
+
+	fs.StringSliceVar(
+		&options.resourceTagMappings,
+		"resource-tag-mapping",
+		defaultTagMapping,
+		"tag a resource (pods, nodes, etc.) span from jsonpath, comma separated. "+
+			"supported setting format: resource[.group]#tagkey1:jsonpath1;tagkey2:jsonpath2, "+
+			"the tag value is parsed from jsonpath. e.g. 'pods#nodes:spec.nodeName;yourTag:status.hostIP,nodes#custom-tag:metadata.name'")
+}
+
+func (options *options) EnableFlag() *bool {
+	return &options.enable
+}
+
+type tagDecorator struct {
+	options            options
+	Logger             logrus.FieldLogger
+	ObjectCache        *objectcache.ObjectCache
+	EventDecorator     eventdecorator.UnionEventDecorator
+	resourceTagMapping map[schema.GroupResource]map[string]string
+}
+
+func (d *tagDecorator) Close() error {
+	return nil
+}
+
+var _ manager.Component = &tagDecorator{}
+
+func (d *tagDecorator) Options() manager.Options {
+	return &d.options
+}
+
+func (d *tagDecorator) Init(ctx context.Context) error {
+	d.EventDecorator.AddDecorator(d)
+	if err := d.registerTagMapping(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *tagDecorator) Start(stopCh <-chan struct{}) error { return nil }
+
+func (d *tagDecorator) registerTagMapping() error {
+	for _, resourceTagMapping := range d.options.resourceTagMappings {
+		slices := strings.Split(resourceTagMapping, "#")
+		if len(slices) != 2 {
+			return fmt.Errorf("invalide resource tag mapping %s", resourceTagMapping)
+		}
+		resource := slices[0]
+		tagMappings := slices[1]
+
+		gv := schema.ParseGroupResource(resource)
+
+		for _, tagMapping := range strings.Split(tagMappings, ";") {
+			tagSlice := strings.Split(tagMapping, ":")
+			if len(tagSlice) != 2 {
+				return fmt.Errorf("invalide tag mapping %s (%s)", resourceTagMapping, tagMapping)
+			}
+			tagKey := tagSlice[0]
+			tagJsonPath := tagSlice[1]
+			d.registerResource(gv, map[string]string{
+				tagKey: tagJsonPath,
+			})
+		}
+	}
+
+	return nil
+}
+
+func (d *tagDecorator) registerResource(gr schema.GroupResource, tagPathMapping map[string]string) {
+	if d.resourceTagMapping == nil {
+		d.resourceTagMapping = map[schema.GroupResource]map[string]string{}
+	}
+
+	if d.resourceTagMapping[gr] == nil {
+		d.resourceTagMapping[gr] = map[string]string{}
+	}
+
+	for tag, path := range tagPathMapping {
+		d.resourceTagMapping[gr][tag] = path
+	}
+}
+
+func (d *tagDecorator) Decorate(ctx context.Context, object util.ObjectRef, event *aggregatorevent.Event) {
+	gr := object.GroupResource()
+	if _, exists := d.resourceTagMapping[gr]; !exists {
+		return
+	}
+
+	raw := object.Raw
+	logger := d.Logger.WithField("object", object)
+
+	if raw == nil {
+		logger.Debug("Fetching dynamic object")
+		var err error
+		raw, err = d.ObjectCache.Get(ctx, object)
+		if err != nil {
+			logger.WithError(err).Error("cannot fetch object value")
+			return
+		}
+
+		if raw == nil {
+			logger.Debug("object no longer exists")
+			return
+		}
+	}
+
+	for tagKey, jsonPath := range d.resourceTagMapping[gr] {
+		val, err := getValFromJsonPath(raw, jsonPath)
+		if err != nil {
+			return
+		}
+		event.Tags[tagKey] = val
+	}
+}
+
+func getValFromJsonPath(obj *unstructured.Unstructured, jsonPath string) (string, error) {
+	parser := jsonpath.New("json path")
+	jsonPath = strings.TrimPrefix(jsonPath, ".")
+	err := parser.Parse(fmt.Sprintf("{.%s}", jsonPath))
+	if err != nil {
+		return "", err
+	}
+	buf := new(bytes.Buffer)
+	err = parser.Execute(buf, obj.Object)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/audit/consumer/consumer.go
+++ b/pkg/audit/consumer/consumer.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/kubewharf/kelemetry/pkg/aggregator"
+	"github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
 	"github.com/kubewharf/kelemetry/pkg/audit"
 	"github.com/kubewharf/kelemetry/pkg/audit/mq"
 	"github.com/kubewharf/kelemetry/pkg/filter"
@@ -268,7 +269,7 @@ func (recv *receiver) handleItem(
 		title += fmt.Sprintf(" (%s)", http.StatusText(int(message.ResponseStatus.Code)))
 	}
 
-	event := aggregator.NewEvent(field, title, message.RequestReceivedTimestamp.Time, "audit").
+	event := aggregatorevent.NewEvent(field, title, message.RequestReceivedTimestamp.Time, "audit").
 		WithEndTime(message.StageTimestamp.Time).
 		WithTag("username", username).
 		WithTag("userAgent", message.UserAgent).

--- a/pkg/diff/decorator/decorator.go
+++ b/pkg/diff/decorator/decorator.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 
-	"github.com/kubewharf/kelemetry/pkg/aggregator"
+	"github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
 	"github.com/kubewharf/kelemetry/pkg/audit"
 	diffcache "github.com/kubewharf/kelemetry/pkg/diff/cache"
 	"github.com/kubewharf/kelemetry/pkg/manager"
@@ -138,7 +138,7 @@ func (decorator *decorator) Close() error {
 	return nil
 }
 
-func (decorator *decorator) Decorate(message *audit.Message, event *aggregator.Event) {
+func (decorator *decorator) Decorate(message *audit.Message, event *aggregatorevent.Event) {
 	logger := decorator.Logger.
 		WithField("audit-id", message.AuditID).
 		WithField("title", event.Title).
@@ -183,7 +183,7 @@ const (
 func (decorator *decorator) tryDecorate(
 	logger logrus.FieldLogger,
 	message *audit.Message,
-	event *aggregator.Event,
+	event *aggregatorevent.Event,
 ) (cacheHitType, metrics.LabeledError) {
 	if message.ResponseStatus != nil && message.ResponseStatus.Code >= 300 {
 		event.Log(zconstants.LogTypeRealError, fmt.Sprintf("%s: %s", message.ResponseStatus.Reason, message.ResponseStatus.Message))
@@ -309,7 +309,7 @@ func (decorator *decorator) tryUpdateOnce(
 	object util.ObjectRef,
 	oldRv string,
 	newRv *string,
-	event *aggregator.Event,
+	event *aggregatorevent.Event,
 	message *audit.Message,
 ) (bool, error) {
 	var err error
@@ -349,7 +349,7 @@ func (decorator *decorator) tryCreateDeleteOnce(
 	ctx context.Context,
 	object util.ObjectRef,
 	snapshotName string,
-	event *aggregator.Event,
+	event *aggregatorevent.Event,
 ) (bool, error) {
 	snapshot, err := decorator.Cache.FetchSnapshot(ctx, object, snapshotName)
 	if err != nil || snapshot == nil {

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/kubewharf/kelemetry/pkg/aggregator"
+	"github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
 	"github.com/kubewharf/kelemetry/pkg/filter"
 	"github.com/kubewharf/kelemetry/pkg/k8s"
 	"github.com/kubewharf/kelemetry/pkg/k8s/discovery"
@@ -293,7 +294,7 @@ func (ctrl *controller) handleEvent(event *corev1.Event) {
 		return
 	}
 
-	aggregatorEvent := aggregator.NewEvent("status", event.Reason, eventTime, "event").
+	aggregatorEvent := aggregatorevent.NewEvent("status", event.Reason, eventTime, "event").
 		WithTag("source", event.Source.Component).
 		WithTag("action", event.Action).
 		Log(zconstants.LogTypeEventMessage, event.Message)

--- a/pkg/frontend/http/redirect/server.go
+++ b/pkg/frontend/http/redirect/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jaegertracing/jaeger/model/json"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -151,7 +152,24 @@ func (server *server) handleGet(ctx *gin.Context, metric *requestMetric) (code i
 	}
 	if len(traceIDs) == 0 {
 		metric.Error = metrics.MakeLabeledError("NoTraceMatch")
-		return 404, fmt.Errorf("could not find trace ids that match query")
+		emptyTrace := json.Trace{
+			Spans: []json.Span{
+				{
+					StartTime: uint64(timestamp.UnixNano() / 1000),
+					Duration:  uint64((time.Minute * 30).Microseconds()),
+					Tags: []json.KeyValue{
+						{Key: "cluster", Value: cluster},
+						{Key: "resource", Value: resource},
+						{Key: "namespace", Value: namespace},
+						{Key: "name", Value: name},
+					},
+					Warnings: []string{"no events found"},
+				},
+			},
+		}
+
+		ctx.JSON(200, emptyTrace)
+		return 0, nil
 	}
 
 	ctx.Redirect(302, fmt.Sprintf("/trace/%s", traceIDs[0].String()))

--- a/pkg/frontend/tf/config/default/default.go
+++ b/pkg/frontend/tf/config/default/default.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/pflag"
+
 	tfconfig "github.com/kubewharf/kelemetry/pkg/frontend/tf/config"
 	tfstep "github.com/kubewharf/kelemetry/pkg/frontend/tf/step"
 	"github.com/kubewharf/kelemetry/pkg/manager"
@@ -31,9 +33,24 @@ func init() {
 	}), tfconfig.Provider.DefaultId)
 }
 
+type options struct {
+	resourceTagsToCollect []string
+}
+
+func (options *options) Setup(fs *pflag.FlagSet) {
+	fs.StringSliceVar(
+		&options.resourceTagsToCollect,
+		"jaeger-transform-collect-object-tags",
+		[]string{"nodes"},
+		"add these tags to object span if it's children spans have these tags. e.g. 'nodes, apiservices.apiregistration.k8s.io'")
+}
+
+func (options *options) EnableFlag() *bool { return nil }
+
 type DefaultProvider struct {
 	manager.MuxImplBase
 
+	options        options
 	configs        map[tfconfig.Id]*tfconfig.Config
 	nameToConfigId map[string]tfconfig.Id
 	defaultConfig  tfconfig.Id
@@ -46,7 +63,7 @@ var (
 
 func (p *DefaultProvider) MuxImplName() (name string, isDefault bool) { return "default", true }
 
-func (p *DefaultProvider) Options() manager.Options { return &manager.NoOptions{} }
+func (p *DefaultProvider) Options() manager.Options { return &p.options }
 
 func (p *DefaultProvider) Init(ctx context.Context) error {
 	p.registerDefaults()
@@ -66,6 +83,7 @@ func (p *DefaultProvider) registerDefaults() {
 		Name: "tree",
 		Steps: []tfconfig.Step{
 			{Visitor: tfstep.ReplaceNameVisitor{}},
+			p.getObjectTagStep(),
 			{Visitor: tfstep.ClusterNameVisitor{}},
 			{Visitor: tfstep.PruneTagsVisitor{}},
 		},
@@ -75,6 +93,7 @@ func (p *DefaultProvider) registerDefaults() {
 		Name: "timeline",
 		Steps: []tfconfig.Step{
 			{Visitor: tfstep.ReplaceNameVisitor{}},
+			p.getObjectTagStep(),
 			{Visitor: tfstep.ExtractNestingVisitor{
 				MatchesNestLevel: func(level string) bool {
 					return true
@@ -89,6 +108,7 @@ func (p *DefaultProvider) registerDefaults() {
 		Name: "tracing",
 		Steps: []tfconfig.Step{
 			{Visitor: tfstep.ReplaceNameVisitor{}},
+			p.getObjectTagStep(),
 			{Visitor: tfstep.ExtractNestingVisitor{
 				MatchesNestLevel: func(level string) bool {
 					return level != "object"
@@ -105,6 +125,7 @@ func (p *DefaultProvider) registerDefaults() {
 		Name: "grouped",
 		Steps: []tfconfig.Step{
 			{Visitor: tfstep.ReplaceNameVisitor{}},
+			p.getObjectTagStep(),
 			{Visitor: tfstep.ExtractNestingVisitor{
 				MatchesNestLevel: func(level string) bool {
 					return level != "object"
@@ -171,6 +192,12 @@ func getCollapseStep() tfconfig.Step {
 			zconstants.LogTypeRealVerbose:    "",
 			zconstants.LogTypeKelemetryError: "_debug",
 		},
+	}}
+}
+
+func (p *DefaultProvider) getObjectTagStep() tfconfig.Step {
+	return tfconfig.Step{Visitor: tfstep.ObjectTagsVisitor{
+		ResourceTags: p.options.resourceTagsToCollect,
 	}}
 }
 

--- a/pkg/frontend/tf/step/object_tags.go
+++ b/pkg/frontend/tf/step/object_tags.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The Kelemetry Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfstep
+
+import (
+	"github.com/jaegertracing/jaeger/model"
+
+	tftree "github.com/kubewharf/kelemetry/pkg/frontend/tf/tree"
+	"github.com/kubewharf/kelemetry/pkg/util/zconstants"
+)
+
+type ObjectTagsVisitor struct {
+	ResourceTags []string
+}
+
+func (visitor ObjectTagsVisitor) Enter(tree tftree.SpanTree, span *model.Span) tftree.TreeVisitor {
+	if tagKv, hasTag := model.KeyValues(span.Tags).FindByKey(zconstants.NestLevel); !hasTag || tagKv.VStr != "object" {
+		return visitor
+	}
+	if _, hasTag := model.KeyValues(span.Tags).FindByKey("resource"); !hasTag {
+		return visitor
+	}
+
+	for _, resourceKey := range visitor.ResourceTags {
+		_ = visitor.findTagRecursively(tree, span, resourceKey)
+	}
+
+	return visitor
+}
+
+func (visitor ObjectTagsVisitor) Exit(tree tftree.SpanTree, span *model.Span) {}
+
+func (visitor ObjectTagsVisitor) findTagRecursively(tree tftree.SpanTree, span *model.Span, tagKey string) model.KeyValue {
+	if kv, hasTag := model.KeyValues(span.Tags).FindByKey(tagKey); hasTag {
+		return kv
+	}
+
+	for childId := range tree.Children(span.SpanID) {
+		childSpan := tree.Span(childId)
+		tagKv, _ := model.KeyValues(childSpan.Tags).FindByKey(zconstants.NestLevel)
+		if tagKv.VStr == "object" {
+			continue
+		}
+		kv := visitor.findTagRecursively(tree, childSpan, tagKey)
+		if len(kv.Key) > 0 {
+			span.Tags = append(span.Tags, kv)
+			return kv
+		}
+	}
+	return model.KeyValue{}
+}

--- a/pkg/imports.go
+++ b/pkg/imports.go
@@ -16,6 +16,8 @@
 package kelemetry_pkg
 
 import (
+	_ "github.com/kubewharf/kelemetry/pkg/aggregator/aggregatorevent"
+	_ "github.com/kubewharf/kelemetry/pkg/aggregator/eventdecorator/tag"
 	_ "github.com/kubewharf/kelemetry/pkg/aggregator/spancache/etcd"
 	_ "github.com/kubewharf/kelemetry/pkg/aggregator/spancache/local"
 	_ "github.com/kubewharf/kelemetry/pkg/aggregator/tracer/otel"


### PR DESCRIPTION

### Description

<!-- What does this PR do? -->
- support to add custom tag for span, and get tag value from json path
- based on object's related resource tag, we can add redirect link to related object
  -  for example, if a pod span has a tag key nodes and tag value is node name, we can add link for tag nodes with linkPatterns configuration in [jaeger-ui](https://www.jaegertracing.io/docs/1.43/frontend-ui/)：
```
      linkPatterns: [
          "type": "tags",
          "key": "nodes",
          "url": "/redirect?cluster=#{cluster}&group=&name=#{nodes}&resource=nodes&ts=#{timeStamp}",
          "text": "#{nodes}"
        }
      ],
```  

![image](https://user-images.githubusercontent.com/22438032/231185908-5aad0080-7a74-449e-adc0-f37537e939a7.png)


### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
