### PR TITLE
perf: never list-watch with cache penetration even on 410 lists

### DIFF
--- a/pkg/diff/controller/controller.go
+++ b/pkg/diff/controller/controller.go
@@ -386,6 +386,10 @@ func (ctrl *controller) startMonitor(gvr schema.GroupVersionResource, apiResourc
 
 	lw := &toolscache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			if options.ResourceVersion == "" {
+				options.ResourceVersion = "0"
+			}
+
 			return reflectorClient.List(ctrl.ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {


### PR DESCRIPTION

### Description
in case of apiserver cache avalanche, kelemetry is unnecessarily requesting the apiserver to penetrate the cache for a full view to all api objects, which further worsens the avalanche condition. meanwhile, kelemetry itself would have preferred the earliest resource version available on the apiserver, and penetrating the watch cache does not help.


<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
