### PR TITLE
fix(objectcache): release entry if operation fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ quickstart:
 	docker-compose -f quickstart.docker-compose.yaml $(COMPOSE_COMMAND)
 
 pre-commit: dot usage test
-	golangci-lint run
+	golangci-lint run --new-from-rev=main
 
 fmt:
 	git add -A

--- a/pkg/k8s/multileader/elector_test.go
+++ b/pkg/k8s/multileader/elector_test.go
@@ -146,14 +146,20 @@ func run(t *testing.T, numProcesses int) {
 					// assert that a crashed leader triggers leader re-election
 				case 1:
 					myLease.Spec.HolderIdentity = pointer.String("someone-else")
-					myLease.Spec.LeaseDurationSeconds = pointer.Int32(600) // an arbitrary number much longer than all other durations in the config
+					myLease.Spec.LeaseDurationSeconds = pointer.Int32(
+						600,
+					) // an arbitrary number much longer than all other durations in the config
 
 					_, err := leases.Update(context.Background(), myLease, metav1.UpdateOptions{})
 					assert.NoError(err)
 
 					<-doneCh // assert that doneCh is closed when the holder identity changes
 
-					err = leases.Delete(context.Background(), myLease.Name, metav1.DeleteOptions{}) // delete the identity to allow subsequent re-acquisition quickly
+					err = leases.Delete(
+						context.Background(),
+						myLease.Name,
+						metav1.DeleteOptions{},
+					) // delete the identity to allow subsequent re-acquisition quickly
 					assert.NoError(err)
 				case 2:
 					close(processStopCh) // assert that closing stopCh breaks the loop

--- a/pkg/k8s/objectcache/objectcache.go
+++ b/pkg/k8s/objectcache/objectcache.go
@@ -137,9 +137,9 @@ func (oc *ObjectCache) Get(ctx context.Context, object util.ObjectRef) (*unstruc
 
 			err = oc.cache.Set(key, valueJson, int(oc.options.storeTtl.Seconds()))
 			if err != nil {
-				// the object is too large, so just don't cache it
 				metric.Error += "/ValueTooLarge"
-				return value, nil
+				// the object is too large, so just don't cache it and return normally
+				return value, nil //nolint:nilerr
 			}
 
 			persisted = true

--- a/pkg/k8s/objectcache/objectcache.go
+++ b/pkg/k8s/objectcache/objectcache.go
@@ -129,6 +129,10 @@ func (oc *ObjectCache) Get(ctx context.Context, object util.ObjectRef) (*unstruc
 				return nil, err
 			}
 
+			if value == nil {
+				return nil, nil
+			}
+
 			valueJson, err := value.MarshalJSON()
 			if err != nil {
 				metric.Error = "FetchedMarshal"

--- a/pkg/k8s/objectcache/objectcache.go
+++ b/pkg/k8s/objectcache/objectcache.go
@@ -16,7 +16,6 @@ package objectcache
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"time"
 
@@ -100,45 +99,80 @@ func (oc *ObjectCache) Get(ctx context.Context, object util.ObjectRef) (*unstruc
 	defer oc.CacheRequestMetric.DeferCount(oc.Clock.Now(), metric)
 
 	key := objectKey(object)
-	randomId := [5]byte{0, 0, 0, 0, 0}
-	_, err := rand.Read(randomId[1:])
-	if err != nil {
-		return nil, fmt.Errorf("generate random initial value: %w", err)
-	}
 
 	for {
-		cached, _ := oc.cache.GetOrSet(key, randomId[:], int(oc.options.fetchTimeout.Seconds()))
+		cached, _ := oc.cache.GetOrSet(key, []byte{0}, int(oc.options.fetchTimeout.Seconds()))
 		if cached != nil {
-			// cache hit
-			metric.Hit = true
-
 			if cached[0] == 0 {
 				// pending; JSON never starts with a NUL byte
-				oc.Clock.Sleep(time.Millisecond * 100) // constant backoff, up to 50 times by default
+				oc.Clock.Sleep(time.Millisecond * 10) // constant backoff until the previous fetchTimeout returns
+				// TODO add metrics to monitor this
 				continue
 			}
 
-			uns := &unstructured.Unstructured{}
-			err := uns.UnmarshalJSON(cached)
+			// cache hit
+			return decodeCached(cached, metric)
+		} else {
+			// cache miss, we have reserved the entry
+
+			persisted := false
+			defer func() {
+				// release the entry on failure
+				if !persisted {
+					oc.cache.Del(key)
+				}
+			}()
+
+			value, err, metricCode := oc.penetrate(ctx, object)
+			metric.Error = metricCode
 			if err != nil {
-				metric.Error = "Unmarshal"
-				return nil, fmt.Errorf("cached invalid data: %w", err)
+				return nil, err
 			}
 
-			metric.Error = "nil"
-			return uns, nil
-		}
+			valueJson, err := value.MarshalJSON()
+			if err != nil {
+				metric.Error = "FetchedMarshal"
+				return nil, fmt.Errorf("server responds with non-marshalable data")
+			}
 
-		// cache miss and reserved
-		break
+			err = oc.cache.Set(key, valueJson, int(oc.options.storeTtl.Seconds()))
+			if err != nil {
+				// the object is too large, so just don't cache it
+				metric.Error += "/ValueTooLarge"
+				return value, nil
+			}
+
+			persisted = true
+
+			return value, nil
+		}
+	}
+}
+
+func decodeCached(cached []byte, metric *CacheRequestMetric) (*unstructured.Unstructured, error) {
+	metric.Hit = true
+
+	uns := &unstructured.Unstructured{}
+	err := uns.UnmarshalJSON(cached)
+	if err != nil {
+		metric.Error = "CacheUnmarshal"
+		return nil, fmt.Errorf("cached invalid data: %w", err)
 	}
 
-	metric.Hit = false
+	metric.Error = "nil"
+	return uns, nil
+}
 
+func (oc *ObjectCache) penetrate(
+	ctx context.Context,
+	object util.ObjectRef,
+) (_raw *unstructured.Unstructured, _err error, _metricCode string) {
+	// first, try fetching from server
 	clusterClient, err := oc.Clients.Cluster(object.Cluster)
 	if err != nil {
-		return nil, fmt.Errorf("cannot initialize clients for cluster %q: %w", object.Cluster, err)
+		return nil, fmt.Errorf("cannot initialize clients for cluster %q: %w", object.Cluster, err), "UnknownCluster"
 	}
+
 	nsClient := clusterClient.DynamicClient().Resource(object.GroupVersionResource)
 	var client dynamic.ResourceInterface = nsClient
 	if object.Namespace != "" {
@@ -149,48 +183,31 @@ func (oc *ObjectCache) Get(ctx context.Context, object util.ObjectRef) (*unstruc
 		ResourceVersion: "0",
 	})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		metric.Error = string(k8serrors.ReasonForError(err))
-		return nil, err
+		return nil, err, string(k8serrors.ReasonForError(err))
 	}
 
 	if err == nil {
-		json, err := raw.MarshalJSON()
-		if err != nil {
-			metric.Error = "Marshal"
-			return nil, fmt.Errorf("server responds with non-marshalable data")
-		}
-
-		err = oc.cache.Set(key, json, int(oc.options.storeTtl.Seconds()))
-		if err != nil {
-			// the object is too large, so just don't cache it
-			metric.Error = "ValueTooLarge"
-		} else {
-			metric.Error = "Penetrated"
-		}
-
-		return raw, nil
+		return raw, nil, "Apiserver"
 	}
-	// else, not found
 
-	metric.Error = "DeletionSnapshot"
-
+	// not found from apiserver, try deletion snapshot instead
 	snapshot, err := oc.DiffCache.FetchSnapshot(ctx, object, diffcache.SnapshotNameDeletion)
 	if err != nil {
-		return nil, metrics.LabelError(fmt.Errorf("cannot fallback to snapshot: %w", err), "SnapshotFetch")
+		return nil, metrics.LabelError(fmt.Errorf("cannot fallback to snapshot: %w", err), "SnapshotFetch"), "SnapshotFetch"
 	}
 
 	if snapshot != nil {
 		uns := &unstructured.Unstructured{}
 		if err := uns.UnmarshalJSON(snapshot.Value); err != nil {
-			return nil, metrics.LabelError(fmt.Errorf("decode snapshot err: %w", err), "SnapshotDecode")
+			return nil, metrics.LabelError(fmt.Errorf("decode snapshot err: %w", err), "SnapshotDecode"), "SnapshotDecode"
 		}
 
-		return uns, nil
+		return uns, nil, "DeletionSnapshot"
 	}
 
 	// all methods failed
 
-	return nil, nil
+	return nil, nil, "NotFoundAnywhere"
 }
 
 func objectKey(object util.ObjectRef) []byte {

--- a/pkg/k8s/objectcache/objectcache_test.go
+++ b/pkg/k8s/objectcache/objectcache_test.go
@@ -86,9 +86,10 @@ func TestGet(t *testing.T) {
 			assert.Equal("bar", fooValue)
 
 			penetrations := metricsOutput.Get("object_cache_request", map[string]string{
-				"error": "Penetrated",
+				"error": "Apiserver",
 				"hit":   "false",
 			})
+			t.Log(metricsOutput.PrintAll())
 			assert.Equal(int64(1), penetrations.Int)
 		} else {
 			assert.True(fooExists)


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

- Reorganize objectcache metrics tags to ensure `error` tag is always meaningful
- Release the objectcache reserve entry upon error

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
