### PR TITLE
perf(diff/controller): remove reference from writerTask to unstructured object

### DIFF
--- a/pkg/diff/controller/controller.go
+++ b/pkg/diff/controller/controller.go
@@ -585,13 +585,15 @@ func (monitor *monitor) onUpdate(
 		patch.DiffList = diffcmp.Compare(oldObj.Object, newObj.Object)
 	}
 
+	objectRef := util.ObjectRefFromUnstructured(newObj, monitor.ctrl.Clients.TargetCluster().ClusterName(), monitor.gvr).Clone()
+
 	return func(ctx context.Context) {
 		ctx, cancelFunc := context.WithTimeout(ctx, monitor.ctrl.options.storeTimeout)
 		defer cancelFunc()
 
 		monitor.ctrl.Cache.Store(
 			ctx,
-			util.ObjectRefFromUnstructured(newObj, monitor.ctrl.Clients.TargetCluster().ClusterName(), monitor.gvr),
+			objectRef,
 			patch,
 		)
 	}
@@ -618,13 +620,19 @@ func (monitor *monitor) onNeedSnapshot(
 			Error("cannot re-marshal unstructured object")
 	}
 
+	objectRef := util.ObjectRefFromUnstructured(obj, monitor.ctrl.Clients.TargetCluster().ClusterName(), monitor.gvr).Clone()
+	snapshotRv := obj.GetResourceVersion()
+
 	return func(ctx context.Context) {
+		ctx, cancelFunc := context.WithTimeout(ctx, monitor.ctrl.options.storeTimeout)
+		defer cancelFunc()
+
 		monitor.ctrl.Cache.StoreSnapshot(
 			ctx,
-			util.ObjectRefFromUnstructured(obj, monitor.ctrl.Clients.TargetCluster().ClusterName(), monitor.gvr),
+			objectRef,
 			snapshotName,
 			&diffcache.Snapshot{
-				ResourceVersion: obj.GetResourceVersion(),
+				ResourceVersion: snapshotRv,
 				Redacted:        redacted, // we still persist redacted objects for ownerReferences lookup
 				Value:           objRaw,
 			},

--- a/pkg/util/object_ref.go
+++ b/pkg/util/object_ref.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,6 +36,24 @@ type ObjectRef struct {
 	Uid types.UID
 
 	Raw *unstructured.Unstructured `json:"-"`
+}
+
+// Returns a new ObjectRef with all strings cloned again
+// to ensure this object does not reference more data than it needs.
+//
+// Does not copy the Raw field.
+func (ref ObjectRef) Clone() ObjectRef {
+	return ObjectRef{
+		Cluster: strings.Clone(ref.Cluster),
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    strings.Clone(ref.Group),
+			Version:  strings.Clone(ref.Version),
+			Resource: strings.Clone(ref.Resource),
+		},
+		Namespace: strings.Clone(ref.Namespace),
+		Name:      strings.Clone(ref.Name),
+		Uid:       types.UID(strings.Clone(string(ref.Uid))),
+	}
 }
 
 func (ref ObjectRef) String() string {


### PR DESCRIPTION


### Description

<!-- What does this PR do? -->

If each writerTask references the entire unstructured object, OOM will happen very quickly.

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
