### PR TITLE
refactor: use ProvideListImpl API for kelemetrix tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,5 @@ fmt:
 	git add -A
 	gofumpt -l -w .
 	golines -m140 --base-formatter=gofumpt -w .
+	goimports -l -w .
 	gci write -s standard -s default -s 'prefix(github.com/kubewharf/kelemetry)' .

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ to reconstruct the causal hierarchy of the actual events.
 - [x] Connect objects with custom rules with multi-cluster support (Plugin API)
 - [x] Navigate trace with Jaeger UI and API
 - [x] Scalable for multiple large clusters
+- [x] Construct tailormade metrics based on audit logs
 
 ```mermaid
 graph TB

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -306,3 +306,9 @@ graph LR
   - `config`: Configuration database for the different display modes.
   - `step`: Implements the transformation steps, used in the config implementations.
 - `tracecache`: Implements the mapping from Cache ID to Trace ID.
+
+### Kelemetrix
+
+Kelemetrix is a separate component that consumes audit logs into metric points.
+Tag providers provide string tags to use in kelemetrix.toml,
+and quantifiers provide scalar quantities.

--- a/pkg/diff/controller/controller.go
+++ b/pkg/diff/controller/controller.go
@@ -45,7 +45,7 @@ import (
 	"github.com/kubewharf/kelemetry/pkg/metrics"
 	"github.com/kubewharf/kelemetry/pkg/util"
 	"github.com/kubewharf/kelemetry/pkg/util/channel"
-	"github.com/kubewharf/kelemetry/pkg/util/informer"
+	informerutil "github.com/kubewharf/kelemetry/pkg/util/informer"
 	"github.com/kubewharf/kelemetry/pkg/util/shutdown"
 )
 

--- a/pkg/kelemetrix/base_quantity_comp.go
+++ b/pkg/kelemetrix/base_quantity_comp.go
@@ -15,12 +15,7 @@
 package kelemetrix
 
 import (
-	"context"
-	"fmt"
-	"strings"
-
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 
 	"github.com/kubewharf/kelemetry/pkg/audit"
 	"github.com/kubewharf/kelemetry/pkg/manager"
@@ -34,46 +29,10 @@ type BaseQuantityDef interface {
 	Quantify(message *audit.Message) (float64, bool, error)
 }
 
-type BaseQuantityOptions[T BaseQuantityDef] struct {
-	Enable bool
-}
-
-func (options *BaseQuantityOptions[T]) Setup(fs *pflag.FlagSet) {
-	var t T
-
-	optionName := strings.ReplaceAll(t.Name(), "_", "-")
-
-	fs.BoolVar(
-		&options.Enable,
-		fmt.Sprintf("kelemetrix-quantity-%s-enable", optionName),
-		t.DefaultEnable(),
-		fmt.Sprintf("enable the %q metric quantity", t.Name()),
-	)
-}
-
-func (options *BaseQuantityOptions[T]) EnableFlag() *bool { return &options.Enable }
-
-type BaseQuantityComp[T BaseQuantityDef] struct {
-	options  BaseQuantityOptions[T]
-	Logger   logrus.FieldLogger
-	Registry *Registry
-
-	Def T `managerRecurse:""`
-}
-
-func (comp *BaseQuantityComp[T]) Options() manager.Options { return &comp.options }
-
-func (comp *BaseQuantityComp[T]) Init() error {
-	comp.Registry.AddQuantifier(&BaseQuantifier[T]{Logger: comp.Logger, Def: comp.Def})
-	return nil
-}
-
-func (comp *BaseQuantityComp[T]) Start(ctx context.Context) error { return nil }
-func (comp *BaseQuantityComp[T]) Close(ctx context.Context) error { return nil }
-
 type BaseQuantifier[T BaseQuantityDef] struct {
+	manager.BaseComponent
 	Logger logrus.FieldLogger
-	Def    T
+	Def    T `managerRecurse:""`
 }
 
 func NewBaseQuantifierForTest[T BaseQuantityDef](def T) *BaseQuantifier[T] {

--- a/pkg/kelemetrix/consumer/consumer.go
+++ b/pkg/kelemetrix/consumer/consumer.go
@@ -249,7 +249,7 @@ func indexQuantifiers(requiredQuantifiers sets.Set[string], registry *kelemetrix
 		}
 
 		quantifierIndex := len(quantifiers)
-		quantifiers = append(quantifiers, registry.Quantifiers[registryIndex])
+		quantifiers = append(quantifiers, registry.Quantifiers.Impls[registryIndex])
 		quantifierNameToIndex[quantifier] = quantifierIndex
 	}
 

--- a/pkg/kelemetrix/consumer/consumer_test.go
+++ b/pkg/kelemetrix/consumer/consumer_test.go
@@ -104,11 +104,7 @@ func TestListTimeout(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 
-	tagProviders := []kelemetrix.TagProvider{}
-	defaulttags.Register(
-		logger,
-		func(tp kelemetrix.TagProvider) { tagProviders = append(tagProviders, tp) },
-	)
+	tagProviders := defaulttags.GetTagProviders(logger)
 
 	clock := clocktesting.NewFakeClock(time.Time{})
 
@@ -248,14 +244,7 @@ func doTestWith(
 		},
 	}
 
-	registry := kelemetrix.NewRegistry()
-
-	for _, tagProvider := range tagProviders {
-		registry.AddTagProvider(tagProvider)
-	}
-	for _, quantifier := range quantifiers {
-		registry.AddQuantifier(quantifier)
-	}
+	registry := kelemetrix.NewMockRegistry(tagProviders, quantifiers)
 
 	consumer := &kelemetrixconsumer.Consumer{
 		Metrics:  metrics,

--- a/pkg/kelemetrix/defaults/quantities/mq_latency.go
+++ b/pkg/kelemetrix/defaults/quantities/mq_latency.go
@@ -25,7 +25,11 @@ import (
 )
 
 func init() {
-	manager.Global.Provide("kelemetrix-quantity-mq-latency", manager.Ptr(&kelemetrix.BaseQuantityComp[MqLatency]{}))
+	manager.Global.ProvideListImpl(
+		"kelemetrix-quantity-mq-latency",
+		manager.Ptr(&kelemetrix.BaseQuantifier[MqLatency]{}),
+		&manager.List[kelemetrix.Quantifier]{},
+	)
 }
 
 type MqLatency struct{}

--- a/pkg/kelemetrix/defaults/quantities/request_count.go
+++ b/pkg/kelemetrix/defaults/quantities/request_count.go
@@ -23,7 +23,11 @@ import (
 )
 
 func init() {
-	manager.Global.Provide("kelemetrix-quantity-request-count", manager.Ptr(&kelemetrix.BaseQuantityComp[RequestCount]{}))
+	manager.Global.ProvideListImpl(
+		"kelemetrix-quantity-request-count",
+		manager.Ptr(&kelemetrix.BaseQuantifier[RequestCount]{}),
+		&manager.List[kelemetrix.Quantifier]{},
+	)
 }
 
 type RequestCount struct{}

--- a/pkg/kelemetrix/defaults/quantities/request_latency.go
+++ b/pkg/kelemetrix/defaults/quantities/request_latency.go
@@ -28,8 +28,16 @@ import (
 )
 
 func init() {
-	manager.Global.Provide("kelemetrix-quantity-request-latency", manager.Ptr(&kelemetrix.BaseQuantityComp[RequestLatency]{}))
-	manager.Global.Provide("kelemetrix-quantity-request-latency-ratio", manager.Ptr(&kelemetrix.BaseQuantityComp[RequestLatencyRatio]{}))
+	manager.Global.ProvideListImpl(
+		"kelemetrix-quantity-request-latency",
+		manager.Ptr(&kelemetrix.BaseQuantifier[RequestLatency]{}),
+		&manager.List[kelemetrix.Quantifier]{},
+	)
+	manager.Global.ProvideListImpl(
+		"kelemetrix-quantity-request-latency-ratio",
+		manager.Ptr(&kelemetrix.BaseQuantifier[RequestLatencyRatio]{}),
+		&manager.List[kelemetrix.Quantifier]{},
+	)
 }
 
 type RequestLatency struct{}

--- a/pkg/kelemetrix/registry.go
+++ b/pkg/kelemetrix/registry.go
@@ -15,27 +15,72 @@
 package kelemetrix
 
 import (
+	"context"
+
 	"github.com/kubewharf/kelemetry/pkg/audit"
 	"github.com/kubewharf/kelemetry/pkg/manager"
 )
 
 func init() {
-	manager.Global.Provide("kelemetrix-registry", manager.Func(NewRegistry))
+	manager.Global.Provide("kelemetrix-registry", manager.Ptr(NewRegistry()))
 }
 
 type Registry struct {
-	manager.BaseComponent
+	TagProviderFactories *manager.List[TagProviderFactory]
 	TagProviders         []TagProvider
 	TagProviderNameIndex map[string]int
-	Quantifiers          []Quantifier
-	QuantifierNameIndex  map[string]int
+
+	Quantifiers         *manager.List[Quantifier]
+	QuantifierNameIndex map[string]int
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
+		TagProviders:         []TagProvider{},
 		TagProviderNameIndex: make(map[string]int),
 		QuantifierNameIndex:  make(map[string]int),
 	}
+}
+
+func NewMockRegistry(
+	tagProviders []TagProvider,
+	quantifiers []Quantifier,
+) *Registry {
+	registry := NewRegistry()
+	for _, tagProvider := range tagProviders {
+		registry.addTagProvider(tagProvider)
+	}
+	registry.Quantifiers = &manager.List[Quantifier]{
+		Impls: quantifiers,
+	}
+	for i, quantifier := range quantifiers {
+		registry.QuantifierNameIndex[quantifier.Name()] = i
+	}
+
+	return registry
+}
+
+func (registry *Registry) Options() manager.Options { return &manager.NoOptions{} }
+
+func (registry *Registry) Init() error {
+	for _, factory := range registry.TagProviderFactories.Impls {
+		for _, provider := range factory.GetTagProviders() {
+			registry.addTagProvider(provider)
+		}
+	}
+
+	for i, quantifier := range registry.Quantifiers.Impls {
+		registry.QuantifierNameIndex[quantifier.Name()] = i
+	}
+
+	return nil
+}
+
+func (registry *Registry) Start(ctx context.Context) error { return nil }
+func (registry *Registry) Close(ctx context.Context) error { return nil }
+
+type TagProviderFactory interface {
+	GetTagProviders() []TagProvider
 }
 
 type TagProvider interface {
@@ -58,17 +103,11 @@ type Quantifier interface {
 	Quantify(message *audit.Message) (float64, bool)
 }
 
-func (registry *Registry) AddTagProvider(provider TagProvider) {
+func (registry *Registry) addTagProvider(provider TagProvider) {
 	providerIndex := len(registry.TagProviders)
 	registry.TagProviders = append(registry.TagProviders, provider)
 
 	for _, name := range provider.TagNames() {
 		registry.TagProviderNameIndex[name] = providerIndex
 	}
-}
-
-func (registry *Registry) AddQuantifier(quantifier Quantifier) {
-	quantifierIndex := len(registry.Quantifiers)
-	registry.Quantifiers = append(registry.Quantifiers, quantifier)
-	registry.QuantifierNameIndex[quantifier.Name()] = quantifierIndex
 }

--- a/pkg/manager/interface.go
+++ b/pkg/manager/interface.go
@@ -85,6 +85,7 @@ type componentInfo struct {
 	component    Component
 	dependents   uint
 	dependencies map[reflect.Type]*componentInfo
+	isListImpl   bool
 }
 
 type utilFactory struct {
@@ -154,7 +155,7 @@ func (manager *Manager) ProvideUtil(factory any) {
 // and return either `T` or `(T, error)`, where `T` is the type of component.
 // The parameter type must be identical to the return type explicitly declared in the factory (not subtypes/supertypes).
 func (manager *Manager) Provide(name string, factory ComponentFactory) {
-	manager.provideComponent(name, factory)
+	manager.provideComponent(name, factory, false)
 }
 
 type ComponentFactory interface {
@@ -264,7 +265,7 @@ type ComponentConstruct interface {
 	ComponentConstruct()
 }
 
-func (manager *Manager) provideComponent(name string, factory ComponentFactory) reflect.Type {
+func (manager *Manager) provideComponent(name string, factory ComponentFactory, isListImpl bool) reflect.Type {
 	compTy := factory.ComponentType()
 	params := factory.Params()
 
@@ -342,6 +343,7 @@ func (manager *Manager) provideComponent(name string, factory ComponentFactory) 
 			component:    comp,
 			dependents:   0,
 			dependencies: deps,
+			isListImpl:   isListImpl,
 		}
 		return info, nil
 	}
@@ -355,7 +357,7 @@ func (manager *Manager) provideComponent(name string, factory ComponentFactory) 
 // It is similar to Manager.Provide(), but with an additional parameter interfaceFunc,
 // where the argument is in the form `Interface.AnyFunc`.
 func (manager *Manager) ProvideMuxImpl(name string, factory ComponentFactory, interfaceFunc any) {
-	compTy := manager.provideComponent(name, factory)
+	compTy := manager.provideComponent(name, factory, false)
 	itfTy := reflect.TypeOf(interfaceFunc).In(0)
 
 	manager.preBuildTasks = append(manager.preBuildTasks, func() {
@@ -365,7 +367,7 @@ func (manager *Manager) ProvideMuxImpl(name string, factory ComponentFactory, in
 }
 
 func (manager *Manager) ProvideListImpl(name string, factory ComponentFactory, list ListInterface) {
-	compTy := manager.provideComponent(name, factory)
+	compTy := manager.provideComponent(name, factory, true)
 
 	listTy := reflect.TypeOf(list)
 	interfaceTy := list.listInterfaceTy()
@@ -382,7 +384,7 @@ func (manager *Manager) ProvideListImpl(name string, factory ComponentFactory, l
 
 func (manager *Manager) initListComponent(list ListInterface) {
 	itfTy := list.listInterfaceTy()
-	manager.provideComponent(itfTy.String()+"-list", list.listFactory(manager))
+	manager.provideComponent(itfTy.String()+"-list", list.listFactory(manager), false)
 }
 
 type List[T any] struct {
@@ -646,11 +648,21 @@ func (manager *Manager) SetupFlags(fs *pflag.FlagSet) {
 
 func (manager *Manager) TrimDisabled(logger logrus.FieldLogger) {
 	for _, comp := range manager.components {
-		enableFlag := comp.component.Options().EnableFlag()
-		if enableFlag != nil && !*enableFlag {
+		if comp.isListImpl {
+			enableFlag := comp.component.Options().EnableFlag()
+
 			dependents := manager.lateDependentsOf[comp.ty]
-			for _, dependent := range dependents {
-				delete(manager.components[dependent].dependencies, comp.ty)
+			if len(dependents) != 1 {
+				panic(fmt.Sprintf("expect exactly 1 dependent for list components, got %v", dependents))
+			}
+
+			listCompTy := dependents[0]
+
+			// For list implementations:
+			// &false = always remove this dependency
+			// &true, nil = enable this dependency if the list is enabled
+			if enableFlag != nil && !(*enableFlag) {
+				delete(manager.components[listCompTy].dependencies, comp.ty)
 				if list, isList := comp.component.(ListInterface); isList {
 					list.listRemoveImpl(comp.component)
 				}
@@ -692,7 +704,7 @@ func (manager *Manager) TrimDisabled(logger logrus.FieldLogger) {
 
 				silentDisable = true
 			} else {
-				if enableFlag != nil {
+				if enableFlag != nil && !comp.isListImpl {
 					shouldDisable = !*enableFlag
 				} else {
 					shouldDisable = comp.dependents == 0
@@ -709,7 +721,7 @@ func (manager *Manager) TrimDisabled(logger logrus.FieldLogger) {
 				disabled[ty] = comp
 
 				if !silentDisable {
-					logger.WithField("mod", comp.name).Warn("Component disabled")
+					logger.WithField("mod", comp.name).Info("Component disabled")
 				}
 			}
 		}


### PR DESCRIPTION
### Description

Auto disable implementations of lists that are not enabled, to avoid unnecessary validation of list impl dependencies.

<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
