### PR TITLE
feat: allow configuring UseOldResourceVersion by cluster

### DIFF
--- a/pkg/aggregator/aggregatorevent/event.go
+++ b/pkg/aggregator/aggregatorevent/event.go
@@ -48,16 +48,16 @@ func (event *Event) GetEndTime() time.Time {
 	return event.Time.Add(zconstants.DummyDuration)
 }
 
-func (event *Event) WithEndTime(when time.Time) *Event {
+func (event *Event) SetEndTime(when time.Time) *Event {
 	event.EndTime = &when
 	return event
 }
 
-func (event *Event) WithDuration(duration time.Duration) *Event {
-	return event.WithEndTime(event.Time.Add(duration))
+func (event *Event) SetDuration(duration time.Duration) *Event {
+	return event.SetEndTime(event.Time.Add(duration))
 }
 
-func (event *Event) WithTag(key string, value any) *Event {
+func (event *Event) SetTag(key string, value any) *Event {
 	event.Tags[key] = value
 	return event
 }

--- a/pkg/audit/consumer/consumer.go
+++ b/pkg/audit/consumer/consumer.go
@@ -257,19 +257,19 @@ func (recv *receiver) handleItem(
 	}
 
 	event := aggregatorevent.NewEvent(title, message.RequestReceivedTimestamp.Time, zconstants.TraceSourceAudit).
-		WithEndTime(message.StageTimestamp.Time).
-		WithTag("username", username).
-		WithTag("userAgent", message.UserAgent).
-		WithTag("responseCode", message.ResponseStatus.Code).
-		WithTag("resourceVersion", message.ObjectRef.ResourceVersion).
-		WithTag("apiserver", message.ApiserverAddr).
-		WithTag("tag", message.Verb)
+		SetEndTime(message.StageTimestamp.Time).
+		SetTag("username", username).
+		SetTag("userAgent", message.UserAgent).
+		SetTag("responseCode", message.ResponseStatus.Code).
+		SetTag("resourceVersion", message.ObjectRef.ResourceVersion).
+		SetTag("apiserver", message.ApiserverAddr).
+		SetTag("tag", message.Verb)
 
 	if len(message.SourceIPs) > 0 {
-		event = event.WithTag("sourceIP", message.SourceIPs[0])
+		event = event.SetTag("sourceIP", message.SourceIPs[0])
 
 		if len(message.SourceIPs) > 1 {
-			event = event.WithTag("proxy", message.SourceIPs[1:])
+			event = event.SetTag("proxy", message.SourceIPs[1:])
 		}
 	}
 

--- a/pkg/diff/api/api.go
+++ b/pkg/diff/api/api.go
@@ -137,15 +137,7 @@ func (api *api) handleGet(ctx *gin.Context) error {
 		Resource: resource,
 	})
 
-	var oldRv string
-	var newRv *string
-	if api.DiffCache.GetCommonOptions().UseOldResourceVersion {
-		oldRv = rv
-	} else {
-		newRv = &rv
-	}
-
-	patch, err := api.DiffCache.Fetch(ctx, object, oldRv, newRv)
+	patch, err := api.DiffCache.Fetch(ctx, object, rv, &rv)
 	if err != nil || patch == nil {
 		return ctx.AbortWithError(404, fmt.Errorf("patch not found for rv: %w", err))
 	}

--- a/pkg/diff/decorator/decorator.go
+++ b/pkg/diff/decorator/decorator.go
@@ -229,6 +229,10 @@ func (decorator *decorator) tryDecorate(
 			return cacheHitTypeSameRv, nil
 		}
 
+		if newRv != nil {
+			event.SetTag("newResourceVersion", *newRv)
+		}
+
 		logger = logger.WithField("oldRv", oldRv).WithField("newRv", newRv)
 
 		tryOnce = func(ctx context.Context) (bool, error) {
@@ -294,7 +298,7 @@ func (decorator *decorator) tryDecorate(
 }
 
 func decoratesResource(message *audit.Message) bool {
-	return message.Verb != audit.VerbPatch
+	return true
 }
 
 func (decorator *decorator) tryUpdateOnce(
@@ -333,7 +337,7 @@ func (decorator *decorator) tryUpdateOnce(
 		},
 		Resource: message.ObjectRef.Resource,
 	}).Histogram(float64(informerLatency.Nanoseconds()))
-	event.WithTag("informer latency", informerLatency)
+	event.SetTag("informer latency", informerLatency)
 
 	return true, nil
 }

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -287,8 +287,8 @@ func (ctrl *controller) handleEvent(ctx context.Context, event *corev1.Event) {
 	}
 
 	aggregatorEvent := aggregatorevent.NewEvent(event.Reason, eventTime, zconstants.TraceSourceEvent).
-		WithTag("source", event.Source.Component).
-		WithTag("action", event.Action).
+		SetTag("source", event.Source.Component).
+		SetTag("action", event.Action).
 		Log(zconstants.LogTypeEventMessage, event.Message)
 
 	cdc, err := ctrl.DiscoveryCache.ForCluster(clusterName)

--- a/pkg/k8s/config/interface.go
+++ b/pkg/k8s/config/interface.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/kubewharf/kelemetry/pkg/manager"
+	"github.com/kubewharf/kelemetry/pkg/metrics"
 )
 
 func init() {
@@ -43,6 +44,24 @@ type Config interface {
 type Cluster struct {
 	Config                *rest.Config
 	DefaultRequestTimeout time.Duration
+	UseOldResourceVersion bool
+}
+
+func (cluster *Cluster) ChooseResourceVersion(oldRv string, newRv *string) (string, error) {
+	useOld := false
+	if cluster != nil {
+		useOld = cluster.UseOldResourceVersion
+	}
+
+	if useOld {
+		return oldRv, nil
+	}
+
+	if newRv != nil {
+		return *newRv, nil
+	}
+
+	return "", metrics.MakeLabeledError("NoNewRv")
 }
 
 type mux struct {


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

Allow choosing resource version per cluster, required because many controllers might interact with non-target controllers.

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
