### PR TITLE
docs: fix the incorrect ref file path in the DEPLOY.md

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -61,7 +61,7 @@ This setup is bundled into a Helm chart.
 
 ## Steps
 
-1. Download [`values.yaml`](charts/kelemetry/values.yaml) and configure the settings.
+1. Download [`values.yaml`](/charts/kelemetry/values.yaml) and configure the settings.
 2. Install the chart: `helm install kelemetry kelemetry oci://ghcr.io/kubewharf/kelemetry-chart --values values.yaml`
 
 The default configuration is designed for single-cluster deployment.


### PR DESCRIPTION
### Description

To fix this error 

```
404 - page not found The main branch of kelemetry does not contain the path `docs/charts/kelemetry/values.yaml`
```



<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
