### PR TITLE
docs: fix helm command

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -62,7 +62,7 @@ This setup is bundled into a Helm chart.
 ## Steps
 
 1. Download [`values.yaml`](/charts/kelemetry/values.yaml) and configure the settings.
-2. Install the chart: `helm install kelemetry kelemetry oci://ghcr.io/kubewharf/kelemetry-chart --values values.yaml`
+2. Install the chart: `helm install kelemetry oci://ghcr.io/kubewharf/kelemetry-chart --values values.yaml`
 
 The default configuration is designed for single-cluster deployment.
 For multi-cluster deployment, configure the `sharedEtcd` and `storageBackend` to use a common database.


### PR DESCRIPTION
### Description

When running the helm command `helm install kelemetry kelemetry oci://ghcr.io/kubewharf/kelemetry-chart --values values.yaml`, the errors `Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments: oci://ghcr.io/kubewharf/kelemetry-chart` under helm version `v3.8.0`.

<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
