### PR TITLE
fix(charts): typo in stateless storage template name

### DIFF
--- a/charts/kelemetry/templates/_helpers.yaml
+++ b/charts/kelemetry/templates/_helpers.yaml
@@ -313,7 +313,7 @@ jaeger-trace-cache-etcd-prefix: {{ .Values.frontend.traceCache.etcd.prefix | toJ
 span-storage.type: grpc-plugin
 grpc-storage.server: {{.Release.Name}}-storage.{{.Release.Namespace}}.svc:17271
 {{- end }}
-{{- define "kelemetry.storage-options-stateless" }}
+{{- define "kelemetry.storage-options-raw-stateless" }}
 span-storage.type: {{toJson .Values.storageBackend.type}}
 {{- range $key, $value := .Values.storageBackend.options }}
 {{ toJson $key }}: {{ toJson $value }}


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->
fix error when installing chart with ES storage backend

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
