### PR TITLE
feat(extension): add http extension trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/coocood/freecache v1.2.3
+	github.com/dlclark/regexp2 v1.10.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/logr v1.2.4
 	github.com/jaegertracing/jaeger v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWa
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/hack/tfconfig.yaml
+++ b/hack/tfconfig.yaml
@@ -77,6 +77,27 @@ modifiers:
 #       # Restrict the number of concurrent queries
 #       maxConcurrency: 4
 
+# http trace extension demo
+#  "00000020":
+#    displayName: http trace extension
+#    modifierName: extension
+#    args:
+#      kind: HTTPTrace
+#      traceBackends:
+#      - tagFilters:
+#          resource: pods
+#          nodes: ".+"
+#        argsTemplates:
+#          node: "{{.nodes}}"
+#          pod: "{{.namespace}}/{{.name}}"
+#          start: "{{unixMicro .start}}"
+#          end: "{{unixMicro .end}}"
+#          limit: "100"
+#        urlTemplate: "http://test-domain/api/traces"
+#        forObject: true
+#      maxConcurrency: 100
+#      totalTimeout: 60s
+
 batches:
   - name: initial
     steps:

--- a/pkg/frontend/extension/httptrace/httptrace.go
+++ b/pkg/frontend/extension/httptrace/httptrace.go
@@ -1,0 +1,352 @@
+// Copyright 2023 The Kelemetry Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httptrace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"text/template"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/sirupsen/logrus"
+
+	"github.com/kubewharf/kelemetry/pkg/frontend/extension"
+	"github.com/kubewharf/kelemetry/pkg/manager"
+	"github.com/kubewharf/kelemetry/pkg/util"
+	filterutil "github.com/kubewharf/kelemetry/pkg/util/filter"
+)
+
+func init() {
+	manager.Global.ProvideListImpl("frontend-extension/http-trace",
+		manager.Ptr(&NodeTraceFactory{}), &manager.List[extension.ProviderFactory]{})
+}
+
+const extensionKind = "HTTPTrace"
+
+type NodeTraceFactory struct {
+	manager.BaseComponent
+	Logger logrus.FieldLogger
+}
+
+func (*NodeTraceFactory) ListIndex() string { return extensionKind }
+
+func (s *NodeTraceFactory) Configure(jsonBuf []byte) (extension.Provider, error) {
+	providerArgs := &ProviderArgs{}
+	if err := json.Unmarshal(jsonBuf, providerArgs); err != nil {
+		return nil, fmt.Errorf("cannot parse httptrace config: %w", err)
+	}
+
+	for i, traceArg := range providerArgs.TraceBackends {
+		argsTemplates := map[string]*template.Template{}
+		for tagKey, templateString := range traceArg.ArgsTemplates {
+			t, err := template.New(tagKey).Funcs(templateFuncs()).Parse(templateString)
+			if err != nil {
+				return nil, fmt.Errorf("invalid tag template %q: %w", tagKey, err)
+			}
+			argsTemplates[tagKey] = t
+		}
+		urlTemplate, err := template.New("url").Funcs(templateFuncs()).Parse(traceArg.URLTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("invalid url template %q: %w", traceArg.URLTemplate, err)
+		}
+		providerArgs.TraceBackends[i].urlTemplate = urlTemplate
+		providerArgs.TraceBackends[i].argsTemplates = argsTemplates
+	}
+
+	totalTimeout, err := time.ParseDuration(providerArgs.TotalTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("parse totalTimeout error: %w", err)
+	}
+
+	return &Provider{
+		logger:         s.Logger,
+		service:        providerArgs.Service,
+		operation:      providerArgs.Operation,
+		traceBackends:  providerArgs.TraceBackends,
+		totalTimeout:   totalTimeout,
+		maxConcurrency: providerArgs.MaxConcurrency,
+		rawConfig:      jsonBuf,
+	}, nil
+}
+
+type ProviderArgs struct {
+	Service   string `json:"service"`
+	Operation string `json:"operation"`
+
+	TraceBackends []TraceBackend `json:"traceBackends"`
+
+	TotalTimeout   string `json:"totalTimeout"`
+	MaxConcurrency int    `json:"maxConcurrency"`
+}
+
+type TraceBackend struct {
+	TagFilters    filterutil.TagFilters `json:"tagFilters"`
+	ArgsTemplates map[string]string     `json:"argsTemplates"`
+	URLTemplate   string                `json:"urlTemplate"`
+
+	ForObject     bool `json:"forObject"`
+	ForAuditEvent bool `json:"forAuditEvent"`
+
+	urlTemplate   *template.Template
+	argsTemplates map[string]*template.Template
+}
+
+type Provider struct {
+	logger         logrus.FieldLogger
+	service        string
+	operation      string
+	traceBackends  []TraceBackend
+	totalTimeout   time.Duration
+	maxConcurrency int
+	rawConfig      []byte
+}
+
+func (provider *Provider) Kind() string { return extensionKind }
+
+func (provider *Provider) RawConfig() []byte { return provider.rawConfig }
+
+func (provider *Provider) TotalTimeout() time.Duration { return provider.totalTimeout }
+func (provider *Provider) MaxConcurrency() int         { return provider.maxConcurrency }
+
+func (provider *Provider) FetchForObject(
+	ctx context.Context,
+	object util.ObjectRef,
+	mainTags model.KeyValues,
+	start, end time.Time,
+) (*extension.FetchResult, error) {
+	var backends []TraceBackend
+	for _, b := range provider.traceBackends {
+		if b.ForObject {
+			backends = append(backends, b)
+		}
+	}
+	if len(backends) == 0 {
+		return nil, nil
+	}
+
+	return provider.fetch(
+		ctx, object, mainTags, start, end,
+		objectTemplateArgs(object),
+		backends,
+	)
+}
+
+func (provider *Provider) FetchForVersion(
+	ctx context.Context,
+	object util.ObjectRef,
+	resourceVersion string,
+	mainTags model.KeyValues,
+	start, end time.Time,
+) (*extension.FetchResult, error) {
+	var backends []TraceBackend
+	for _, b := range provider.traceBackends {
+		if b.ForAuditEvent {
+			backends = append(backends, b)
+		}
+	}
+	if len(backends) == 0 {
+		return nil, nil
+	}
+
+	templateArgs := objectTemplateArgs(object)
+	templateArgs["resourceVersion"] = resourceVersion
+
+	return provider.fetch(
+		ctx, object, mainTags, start, end,
+		templateArgs,
+		backends,
+	)
+}
+
+type identifier struct {
+	TraceIds []model.TraceID `json:"traceIds"`
+	Start    time.Time       `json:"start"`
+	End      time.Time       `json:"end"`
+}
+
+func (provider *Provider) LoadCache(ctx context.Context, jsonBuf []byte) ([]*model.Span, error) {
+	var ident identifier
+	if err := json.Unmarshal(jsonBuf, &ident); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal cached identifier: %w", err)
+	}
+
+	var spans []*model.Span
+
+	for _, traceId := range ident.TraceIds {
+		trace, err := provider.getTrace(ctx, traceId)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get trace from extension storage: %w", err)
+		}
+
+		spans = append(spans, trace.Spans...)
+	}
+
+	return spans, nil
+}
+
+func objectTemplateArgs(object util.ObjectRef) map[string]any {
+	return map[string]any{
+		"cluster":       object.Cluster,
+		"group":         object.Group,
+		"version":       object.Version,
+		"resource":      object.Resource,
+		"groupVersion":  object.GroupVersionResource.GroupVersion().String(),
+		"groupResource": object.GroupVersionResource.GroupResource().String(),
+		"namespace":     object.Namespace,
+		"name":          object.Name,
+	}
+}
+
+// fetch returns traces search from first successful traceBackend
+func (provider *Provider) fetch(
+	ctx context.Context,
+	_ util.ObjectRef,
+	mainTags model.KeyValues,
+	start, end time.Time,
+	templateArgs map[string]any,
+	traceBackends []TraceBackend,
+) (*extension.FetchResult, error) {
+	for _, mainTag := range mainTags {
+		templateArgs[mainTag.Key] = mainTag.Value()
+	}
+
+	templateArgs["start"] = start
+	templateArgs["end"] = end
+
+	stringTags := map[string]string{}
+	for key, val := range templateArgs {
+		if strVal, ok := val.(string); ok {
+			stringTags[key] = strVal
+		}
+	}
+
+	for _, traceBackend := range traceBackends {
+		if !traceBackend.TagFilters.Check(stringTags) {
+			continue
+		}
+
+		queryArgs := map[string]string{}
+		for tagKey, tagTemplate := range traceBackend.argsTemplates {
+			buf := new(bytes.Buffer)
+			err := tagTemplate.Execute(buf, templateArgs)
+			if err != nil {
+				return nil, fmt.Errorf("cannot execute tag template: %w", err)
+			}
+
+			queryArgs[tagKey] = buf.String()
+		}
+
+		buf := new(bytes.Buffer)
+		err := traceBackend.urlTemplate.Execute(buf, templateArgs)
+		if err != nil {
+			return nil, fmt.Errorf("cannot execute tag template: %w", err)
+		}
+		traceUrl := buf.String()
+
+		traces, err := provider.findTraces(ctx, traceUrl, queryArgs)
+		provider.logger.
+			WithField("url", traceUrl).
+			WithField("args", queryArgs).
+			WithField("startTime", start).
+			WithField("endTime", end).
+			WithError(err).
+			Info("search node traces")
+		if err != nil {
+			continue
+		}
+
+		var traceIds []model.TraceID
+		var spans []*model.Span
+		for _, trace := range traces {
+			if len(trace.Spans) == 0 {
+				continue
+			}
+
+			traceIds = append(traceIds, trace.Spans[0].TraceID)
+			spans = append(spans, trace.Spans...)
+		}
+
+		return &extension.FetchResult{
+			Identifier: identifier{
+				TraceIds: traceIds,
+				Start:    start,
+				End:      end,
+			},
+			Spans: spans,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (provider *Provider) findTraces(ctx context.Context, traceUrl string, queryArgs map[string]string) ([]*model.Trace, error) {
+	query := url.Values{}
+	for k, v := range queryArgs {
+		query.Add(k, v)
+	}
+	traceUrl = fmt.Sprintf("%s?%s", traceUrl, query.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, traceUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(res.Body)
+	defer res.Body.Close()
+	if res.StatusCode > 299 {
+		return nil, fmt.Errorf("response failed with status code: %d and body: %s", res.StatusCode, string(body))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read response error: %w", err)
+	}
+
+	var traces TraceResponse
+	if err := json.Unmarshal(body, &traces); err != nil {
+		return nil, fmt.Errorf("cannot parse HTTP extension response: %w", err)
+	}
+
+	return traces.Data, nil
+}
+
+type TraceResponse struct {
+	Data []*model.Trace
+}
+
+// TODO
+func (provider *Provider) getTrace(ctx context.Context, traceId model.TraceID) (*model.Trace, error) {
+	return nil, fmt.Errorf("trace cache for HTTP extension is unimplemented")
+}
+
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"unixMicro": unixMicro,
+	}
+}
+
+func unixMicro(t interface{}) string {
+	if tt, ok := t.(time.Time); ok {
+		return fmt.Sprintf("%v", tt.UnixMicro())
+	}
+	return ""
+}

--- a/pkg/imports.go
+++ b/pkg/imports.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/kubewharf/kelemetry/pkg/frontend"
 	_ "github.com/kubewharf/kelemetry/pkg/frontend/backend/jaeger-storage"
 	_ "github.com/kubewharf/kelemetry/pkg/frontend/clusterlist/options"
+	_ "github.com/kubewharf/kelemetry/pkg/frontend/extension/httptrace"
 	_ "github.com/kubewharf/kelemetry/pkg/frontend/extension/jaeger-storage"
 	_ "github.com/kubewharf/kelemetry/pkg/frontend/http/redirect"
 	_ "github.com/kubewharf/kelemetry/pkg/frontend/http/trace"

--- a/pkg/util/filter/object_filter.go
+++ b/pkg/util/filter/object_filter.go
@@ -1,0 +1,86 @@
+// Copyright 2023 The Kelemetry Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"github.com/dlclark/regexp2"
+
+	"github.com/kubewharf/kelemetry/pkg/util"
+)
+
+type ObjectFilters struct {
+	Cluster   Regex `json:"cluster"`
+	Group     Regex `json:"group"`
+	Version   Regex `json:"version"`
+	Resource  Regex `json:"resource"`
+	Namespace Regex `json:"namespace"`
+	Name      Regex `json:"name"`
+}
+
+type Regex struct {
+	// golang regex not support (?!..), use third party regular engine for go
+	Pattern *regexp2.Regexp
+}
+
+func (regex *Regex) UnmarshalText(text []byte) (err error) {
+	regex.Pattern, err = regexp2.Compile(string(text), 0)
+	return err
+}
+
+func (regex *Regex) MatchString(s string) bool {
+	match, _ := regex.Pattern.MatchString(s)
+	return match
+}
+
+func (f *ObjectFilters) Check(object util.ObjectRef) bool {
+	if f.Cluster.Pattern != nil && !f.Cluster.MatchString(object.Cluster) {
+		return false
+	}
+
+	if f.Group.Pattern != nil && !f.Group.MatchString(object.Group) {
+		return false
+	}
+
+	if f.Version.Pattern != nil && !f.Version.MatchString(object.Version) {
+		return false
+	}
+
+	if f.Resource.Pattern != nil && !f.Resource.MatchString(object.Resource) {
+		return false
+	}
+
+	if f.Namespace.Pattern != nil && !f.Namespace.MatchString(object.Namespace) {
+		return false
+	}
+
+	if f.Name.Pattern != nil && !f.Name.MatchString(object.Name) {
+		return false
+	}
+
+	return true
+}
+
+type TagFilters map[string]Regex
+
+func (f TagFilters) Check(tags map[string]string) bool {
+	for key, filter := range f {
+		val := tags[key]
+		if filter.Pattern != nil && !filter.MatchString(val) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->
some trace systems may not support jaeger-storage-plugin api, so add trace extension support for general http api

- the external trace api must return <code>[]*[model.Trace](https://github.com/jaegertracing/jaeger/blob/e0c83b0817e5477c161cc148bbad9cbc16a6827f/model/model.pb.go#L459)</code>
- http url can be rendered by go template
- call http trace extension for the object trace spans which match tags filter

this is transform-config demo for pod runtime trace extension:
```
  "00000020":
    displayName: http trace extension
    modifierName: extension
    args:
      kind: HTTPTrace
      traceBackends:
      - tagFilters:
          resource: pods
          nodes: ".+"
        argsTemplates:
          node: "{{.nodes}}"
          pod: "{{.namespace}}/{{.name}}"
          start: "{{unixMicro .start}}"
          end: "{{unixMicro .end}}"
          limit: "100"
        urlTemplate: "http://127.0.0.1:16686/api/traces"
        forObject: true
      maxConcurrency: 100
      totalTimeout: 60s
```

display demo:
![image](https://github.com/kubewharf/kelemetry/assets/22438032/29bd9bc5-a494-47d9-8c1f-77893da76813)


### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
