### PR TITLE
fix(tfconfig): hide managedFields in default tfconfig

### DIFF
--- a/hack/tfconfig.yaml
+++ b/hack/tfconfig.yaml
@@ -126,6 +126,10 @@ batches:
               fields:
                 - "metadata.resourceVersion"
                 - "metadata.generation"
+            - class:
+                shouldDisplay: false
+              fields:
+                - "metadata.managedFields"
         logTypeMapping:
           event/message: "message"
           audit/objectSnapshot: "snapshot"

--- a/pkg/frontend/tf/defaults/step/collapse_nesting.go
+++ b/pkg/frontend/tf/defaults/step/collapse_nesting.go
@@ -94,8 +94,10 @@ type AuditDiffClass struct {
 }
 
 func (classes *AuditDiffClassification) Get(prefix string) *AuditDiffClass {
-	if class, hasSpecific := classes.SpecificFields.fieldMap[prefix]; hasSpecific {
-		return class
+	for ptr := len(prefix); ptr > 0; ptr = strings.LastIndex(prefix[:ptr], ".") { // remove the last `.`-delimited substring if not found
+		if class, hasSpecific := classes.SpecificFields.fieldMap[prefix[:ptr]]; hasSpecific {
+			return class
+		}
 	}
 
 	return &classes.DefaultClass


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

Hide the verbose `managedFields` diff when server-side-apply is enabled.

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
