### PR TITLE
chore: limit memory usage for storage containers in make stack/quickstart

### DIFF
--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -1,7 +1,7 @@
 # docker-compose setup for development setup.
 # Use quickstart.docker-compose.yaml if you just want to try out Kelemetry.
 # Use the helm chart if you want to deploy in production.
-version: "2.2"
+version: "3"
 services:
   # ETCD cache storage, only required if etcd cache is used
   etcd:
@@ -22,6 +22,10 @@ services:
     ports:
       - 2379:2379
     restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 1G
   # Web frontend for trace view.
   jaeger-query:
     image: jaegertracing/jaeger-query:1.42
@@ -55,6 +59,10 @@ services:
     volumes:
       - badger:/mnt/badger
     restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 1G
 
   # Web frontend for raw trace database view.
   jaeger-query-raw:

--- a/quickstart.docker-compose.yaml
+++ b/quickstart.docker-compose.yaml
@@ -1,7 +1,7 @@
 # docker-compose setup for quick preview.
 # Use dev.docker-compose.yaml if you want to debug a local build.
 # Use the helm chart if you want to deploy in production.
-version: "2.2"
+version: "3"
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.2
@@ -19,6 +19,10 @@ services:
     volumes:
       - etcd:/var/run/etcd/default.etcd
     restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 1G
   jaeger-query:
     image: jaegertracing/jaeger-query:1.42
     environment:
@@ -43,6 +47,10 @@ services:
       BADGER_DIRECTORY_VALUE: /mnt/badger/data
     volumes:
       - badger:/mnt/badger
+    deploy:
+      resources:
+        limits:
+          memory: 1G
   kelemetry:
     command: [
       "kelemetry",


### PR DESCRIPTION

### Description

storage services easily cause system OOM due to accumulating data, prevent it by restricting the container directly

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
