### PR TITLE
Fix: make sed/find command of makefile compatible under mac os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,12 @@ dot: output/kelemetry
 	dot -Tpng depgraph.dot >depgraph.png
 	dot -Tsvg depgraph.dot >depgraph.svg
 
-output/kelemetry: go.mod go.sum $(shell find -type f -name "*.go")
+FIND_PATH = 
+ifeq ($(OS_NAME), Darwin)
+	FIND_PATH = .
+endif
+
+output/kelemetry: go.mod go.sum $(shell find $(FIND_PATH) -type f -name "*.go")
 	go build -v $(RACE_ARG) -gcflags=$(GCFLAGS) -ldflags=$(LDFLAGS) -o $@ $(BUILD_ARGS) .
 
 kind:
@@ -160,6 +165,11 @@ define QUICKSTART_JQ_PATCH
 			if $$KELEMETRY_IMAGE != "" then .services.kelemetry.image = $$KELEMETRY_IMAGE else . end
 endef
 
+SED_I_FLAG = 
+ifeq ($(OS_NAME), Darwin)
+  SED_I_FLAG = ''
+endif
+
 export QUICKSTART_JQ_PATCH
 quickstart:
 	echo $(COMPOSE_COMMAND)
@@ -167,8 +177,10 @@ quickstart:
 		-f <(jq -n --arg KELEMETRY_IMAGE "$(KELEMETRY_IMAGE)" "$$QUICKSTART_JQ_PATCH") \
 		up --no-recreate --no-start
 	kubectl config view --raw --minify --flatten --merge >hack/client-kubeconfig.local.yaml
-	sed -i "s/0\.0\.0\.0/$$(docker network inspect kelemetry_default -f '{{(index .IPAM.Config 0).Gateway}}')/g" hack/client-kubeconfig.local.yaml
-	sed -i 's/certificate-authority-data: .*$$/insecure-skip-tls-verify: true/' hack/client-kubeconfig.local.yaml
+
+	sed -i $(SED_I_FLAG) "s/0\.0\.0\.0/$$(docker network inspect kelemetry_default -f '{{(index .IPAM.Config 0).Gateway}}')/g" hack/client-kubeconfig.local.yaml
+	sed -i $(SED_I_FLAG) 's/certificate-authority-data: .*$$/insecure-skip-tls-verify: true/' hack/client-kubeconfig.local.yaml
+
 	docker compose -f quickstart.docker-compose.yaml \
 		-f <(jq -n --arg KELEMETRY_IMAGE "$(KELEMETRY_IMAGE)" "$$QUICKSTART_JQ_PATCH") \
 		$(COMPOSE_COMMAND)


### PR DESCRIPTION
### Description

Try to fix the errors of running makefile under mac os

The warning message of `find` command and the error message of `sed` command .

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
