### PR TITLE
feat(linker): get owner reference from creation snapshot first

### DIFF
--- a/pkg/diff/cache/interface.go
+++ b/pkg/diff/cache/interface.go
@@ -162,14 +162,14 @@ func (mux *mux) GetCommonOptions() *CommonOptions {
 
 func (mux *mux) Store(ctx context.Context, object utilobject.Key, patch *Patch) {
 	defer mux.StoreDiffMetric.DeferCount(mux.Clock.Now(), &storeDiffMetric{Redacted: patch.Redacted})
-	mux.Impl().(Cache).Store(ctx, object, patch)
+	mux.impl.Store(ctx, object, patch)
 }
 
 func (mux *mux) Fetch(ctx context.Context, object utilobject.Key, oldResourceVersion string, newResourceVersion *string) (*Patch, error) {
 	metric := &fetchDiffMetric{}
 	defer mux.FetchDiffMetric.DeferCount(mux.Clock.Now(), metric)
 
-	patch, err := mux.Impl().(Cache).Fetch(ctx, object, oldResourceVersion, newResourceVersion)
+	patch, err := mux.impl.Fetch(ctx, object, oldResourceVersion, newResourceVersion)
 	if err != nil {
 		metric.Error = err
 		return nil, err
@@ -181,14 +181,14 @@ func (mux *mux) Fetch(ctx context.Context, object utilobject.Key, oldResourceVer
 
 func (mux *mux) StoreSnapshot(ctx context.Context, object utilobject.Key, snapshotName string, snapshot *Snapshot) {
 	defer mux.StoreSnapshotMetric.DeferCount(mux.Clock.Now(), &storeSnapshotMetric{Redacted: snapshot.Redacted})
-	mux.Impl().(Cache).StoreSnapshot(ctx, object, snapshotName, snapshot)
+	mux.impl.StoreSnapshot(ctx, object, snapshotName, snapshot)
 }
 
 func (mux *mux) FetchSnapshot(ctx context.Context, object utilobject.Key, snapshotName string) (*Snapshot, error) {
 	metric := &fetchSnapshotMetric{}
 	defer mux.FetchSnapshotMetric.DeferCount(mux.Clock.Now(), metric)
 
-	snapshot, err := mux.Impl().(Cache).FetchSnapshot(ctx, object, snapshotName)
+	snapshot, err := mux.impl.FetchSnapshot(ctx, object, snapshotName)
 	if err != nil {
 		metric.Error = err
 		return nil, err
@@ -200,5 +200,5 @@ func (mux *mux) FetchSnapshot(ctx context.Context, object utilobject.Key, snapsh
 
 func (mux *mux) List(ctx context.Context, object utilobject.Key, limit int) ([]string, error) {
 	defer mux.ListMetric.DeferCount(mux.Clock.Now(), &listMetric{})
-	return mux.Impl().(Cache).List(ctx, object, limit)
+	return mux.impl.List(ctx, object, limit)
 }

--- a/pkg/diff/cache/memory_wrapper.go
+++ b/pkg/diff/cache/memory_wrapper.go
@@ -136,6 +136,9 @@ func (wrapper *CacheWrapper) FetchSnapshot(
 	penetrateMetric.Penetrate = true
 
 	patch, err := wrapper.delegate.FetchSnapshot(ctx, object, snapshotName)
+	if patch != nil && err == nil {
+		wrapper.patchCache.Add(cacheWrapperKey(object, snapshotName), patch)
+	}
 	return patch, err
 }
 

--- a/pkg/ownerlinker/linker.go
+++ b/pkg/ownerlinker/linker.go
@@ -20,9 +20,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/clock"
 
 	"github.com/kubewharf/kelemetry/pkg/aggregator/linker"
+	diffcache "github.com/kubewharf/kelemetry/pkg/diff/cache"
 	"github.com/kubewharf/kelemetry/pkg/k8s"
 	"github.com/kubewharf/kelemetry/pkg/k8s/discovery"
 	"github.com/kubewharf/kelemetry/pkg/k8s/objectcache"
@@ -48,11 +51,21 @@ func (options *options) EnableFlag() *bool { return &options.enable }
 
 type Controller struct {
 	options        options
+	Clock          clock.Clock
 	Logger         logrus.FieldLogger
 	Clients        k8s.Clients
 	DiscoveryCache discovery.DiscoveryCache
 	ObjectCache    *objectcache.ObjectCache
+	DiffCache      diffcache.Cache
+	LinkerMetric   *metrics.Metric[*linkerMetric]
 }
+
+type linkerMetric struct {
+	Cluster string
+	Fetch   string
+}
+
+func (*linkerMetric) MetricName() string { return "owner_linker_lookup" }
 
 var _ manager.Component = &Controller{}
 
@@ -63,6 +76,9 @@ func (ctrl *Controller) Close(ctx context.Context) error { return nil }
 
 func (ctrl *Controller) LinkerName() string { return "owner-linker" }
 func (ctrl *Controller) Lookup(ctx context.Context, object utilobject.Rich) ([]linker.LinkerResult, error) {
+	metric := &linkerMetric{Cluster: object.Cluster, Fetch: "Unknown"}
+	defer ctrl.LinkerMetric.DeferCount(ctrl.Clock.Now(), metric)
+
 	raw := object.Raw
 
 	logger := ctrl.Logger.WithFields(object.AsFields("object"))
@@ -70,16 +86,33 @@ func (ctrl *Controller) Lookup(ctx context.Context, object utilobject.Rich) ([]l
 	if raw == nil {
 		logger.Debug("Fetching dynamic object")
 
-		var err error
-		raw, err = ctrl.ObjectCache.Get(ctx, object.VersionedKey)
+		// try creation snapshot first
+		snapshot, err := ctrl.DiffCache.FetchSnapshot(ctx, object.Key, diffcache.SnapshotNameCreation)
 		if err != nil {
-			return nil, metrics.LabelError(fmt.Errorf("cannot fetch object value from cache: %w", err), "FetchCache")
+			return nil, fmt.Errorf("cannot fallback to snapshot: %w", err)
+		}
+
+		if snapshot != nil {
+			raw = &unstructured.Unstructured{}
+			if err := raw.UnmarshalJSON(snapshot.Value); err != nil {
+				return nil, fmt.Errorf("decode snapshot err: %w", err)
+			}
+			metric.Fetch = "Snapshot"
+		} else {
+			var err error
+			raw, err = ctrl.ObjectCache.Get(ctx, object.VersionedKey)
+			if err != nil {
+				return nil, fmt.Errorf("cannot fetch object value from cache: %w", err)
+			}
+			metric.Fetch = "ObjectCache"
 		}
 
 		if raw == nil {
 			logger.Debug("object no longer exists")
 			return nil, nil
 		}
+	} else {
+		metric.Fetch = "Raw"
 	}
 
 	var results []linker.LinkerResult


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

- get owner reference from creation snapshot first to reduce apiserver request
- linker.Lookup is called when create link spans and alse when create new object spans. for a new object, usually creation audti will fetch creation snapshot once and cache snapshot in local memory, so it will not lead to more fetching request to cache storage.


### Related issues


### Special notes for your reviewer:

<!-- if any -->
