### PR TITLE
fix(diff): disable diff patch memory cache

### DIFF
--- a/pkg/diff/cache/interface.go
+++ b/pkg/diff/cache/interface.go
@@ -55,7 +55,7 @@ type CommonOptions struct {
 }
 
 func (options *CommonOptions) Setup(fs *pflag.FlagSet) {
-	fs.DurationVar(&options.PatchTtl, "diff-cache-patch-ttl", 0, "duration for which patch cache remains (0 to disable TTL)")
+	fs.DurationVar(&options.PatchTtl, "diff-cache-patch-ttl", time.Minute*10, "duration for which patch cache remains (0 to disable TTL)")
 	fs.DurationVar(
 		&options.SnapshotTtl,
 		"diff-cache-snapshot-ttl",

--- a/pkg/diff/cache/memory_wrapper.go
+++ b/pkg/diff/cache/memory_wrapper.go
@@ -50,9 +50,7 @@ func newCacheWrapper(
 		options:         options,
 		clock:           clock,
 	}
-	if options.PatchTtl > 0 {
-		cacheWrapper.patchCache = cache.NewTtlOnce(options.PatchTtl, clock)
-	}
+
 	if options.SnapshotTtl > 0 {
 		cacheWrapper.snapshotCache = cache.NewTtlOnce(options.SnapshotTtl, clock)
 	}


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->

- disable diff patch memory cache
- enable diff-cache-patch-ttl by default


### Related issues


<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
