### PR TITLE
fix(diff): diff controller would deadlock when leader re-elects

### DIFF
--- a/pkg/diff/controller/controller.go
+++ b/pkg/diff/controller/controller.go
@@ -432,9 +432,6 @@ func (ctrl *controller) drainMonitors(gvrs []schema.GroupVersionResource) []*mon
 }
 
 func (ctrl *controller) drainAllMonitors() []*monitor {
-	ctrl.monitorsLock.Lock()
-	defer ctrl.monitorsLock.Unlock()
-
 	monitors := make([]*monitor, 0, len(ctrl.monitors))
 	for gvr := range ctrl.monitors {
 		monitors = append(monitors, ctrl.monitors[gvr])

--- a/pkg/util/channel/channel.go
+++ b/pkg/util/channel/channel.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -280,3 +281,17 @@ func (q *Deque[T]) Compact(ratio float64) {
 }
 
 func zero[T any]() (zero T) { return }
+
+func NoisyWaitChannelClose(ctx context.Context, ch <-chan struct{}, period time.Duration, doLog func(string)) {
+	for {
+		select {
+		case <-ch:
+			return
+		case <-time.After(period):
+			doLog("waiting for channel close...")
+		case <-ctx.Done():
+			doLog("base context closed")
+			return
+		}
+	}
+}


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->
When diff controller exits, there is a mutex reentrance deadlock bug that prevents the next leader session from acquiring the lock to continue watching.

<img width="296" alt="image" src="https://github.com/user-attachments/assets/710af7a9-91c4-46d7-86a4-6ba9a99f60a6">

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
