### PR TITLE
fix(audit/webhook): set a limit to the webhook queue length

### DIFF
--- a/pkg/audit/webhook/webhook.go
+++ b/pkg/audit/webhook/webhook.go
@@ -46,7 +46,12 @@ type options struct {
 
 func (options *options) Setup(fs *pflag.FlagSet) {
 	fs.BoolVar(&options.enable, "audit-webhook-enable", false, "enable audit webhook")
-	fs.BoolVar(&options.enable, "audit-webhook-subscriber-queue-capacity", false, "maximum number of events buffered in the webhook, set to 0 for an unbounded buffer (may cause OOM)")
+	fs.BoolVar(
+		&options.enable,
+		"audit-webhook-subscriber-queue-capacity",
+		false,
+		"maximum number of events buffered in the webhook, set to 0 for an unbounded buffer (may cause OOM)",
+	)
 }
 
 func (options *options) EnableFlag() *bool { return &options.enable }

--- a/pkg/util/channel/channel.go
+++ b/pkg/util/channel/channel.go
@@ -46,7 +46,7 @@ func (ch BoundedQueue[T]) GetAndResetLength() int {
 	return len(ch) // for simplicity we just return the channel length
 }
 
-func (ch BoundedQueue[T]) Receiver() <-chan T{
+func (ch BoundedQueue[T]) Receiver() <-chan T {
 	return ch
 }
 


### PR DESCRIPTION
### Description

Use a bounded channel for audit producer to avoid webhook OOM when the message queue cannot be pushed to (e.g. kafka upstream connectivity issues)
