### PR TITLE
feat(frontend): search spans from extension tracers when object name is specified

### DIFF
--- a/pkg/frontend/tf/tree/tree.go
+++ b/pkg/frontend/tf/tree/tree.go
@@ -83,6 +83,20 @@ func (tree *SpanTree) Clone() (*SpanTree, error) {
 	return NewSpanTree(copiedSpans), nil
 }
 
+func CopySpans(spans []*model.Span) ([]*model.Span, error) {
+	copiedSpans := make([]*model.Span, 0, len(spans))
+	for _, span := range spans {
+		spanCopy, err := CopySpan(span)
+		if err != nil {
+			return nil, err
+		}
+
+		copiedSpans = append(copiedSpans, spanCopy)
+	}
+
+	return copiedSpans, nil
+}
+
 func CopySpan(span *model.Span) (*model.Span, error) {
 	spanJson, err := json.Marshal(span)
 	if err != nil {

--- a/pkg/frontend/tracecache/interface.go
+++ b/pkg/frontend/tracecache/interface.go
@@ -48,6 +48,7 @@ type EntryValue struct {
 	RootObject  *utilobject.Key   `json:"rootObject"`
 
 	Extensions []ExtensionCache `json:"extensions"`
+	Spans      []*model.Span    `json:"spans"`
 }
 
 type ExtensionCache struct {


### PR DESCRIPTION


### Description

- when searched object has no events during this period, try to discover any possible spans from extension tracers.


<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
