### PR TITLE
fix(webhook): incorrect audit-webhook-subscriber-queue-capacity argument handling

### DIFF
--- a/pkg/audit/webhook/webhook.go
+++ b/pkg/audit/webhook/webhook.go
@@ -46,10 +46,10 @@ type options struct {
 
 func (options *options) Setup(fs *pflag.FlagSet) {
 	fs.BoolVar(&options.enable, "audit-webhook-enable", false, "enable audit webhook")
-	fs.BoolVar(
-		&options.enable,
+	fs.IntVar(
+		&options.subscriberQueueCapacity,
 		"audit-webhook-subscriber-queue-capacity",
-		false,
+		0,
 		"maximum number of events buffered in the webhook, set to 0 for an unbounded buffer (may cause OOM)",
 	)
 }


### PR DESCRIPTION


### Description

fix incorrect argument registration in #363

<!-- What does this PR do? -->

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
