### PR TITLE
perf: intern decayinginformer strings with unique package

### DIFF
--- a/pkg/util/informer/decaying_informer.go
+++ b/pkg/util/informer/decaying_informer.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubewharf/kelemetry/pkg/util/channel"
+	reflectutil "github.com/kubewharf/kelemetry/pkg/util/reflect"
 )
 
 // DecayingInformer is an informer that only supports delta handling.
@@ -153,8 +154,8 @@ type Decayed struct {
 
 func DecayedOf[V metav1.Object](obj V) *Decayed {
 	return &Decayed{
-		namespace:       strings.Clone(obj.GetNamespace()),
-		name:            strings.Clone(obj.GetName()),
+		namespace:       reflectutil.InternString(obj.GetNamespace()),
+		name:            reflectutil.InternString(obj.GetName()),
 		resourceVersion: strings.Clone(obj.GetResourceVersion()),
 	}
 }

--- a/pkg/util/object/key.go
+++ b/pkg/util/object/key.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	reflectutil "github.com/kubewharf/kelemetry/pkg/util/reflect"
 )
 
 type Key struct {
@@ -33,10 +35,10 @@ type Key struct {
 
 func (key Key) Clone() Key {
 	return Key{
-		Cluster:   strings.Clone(key.Cluster),
-		Group:     strings.Clone(key.Group),
-		Resource:  strings.Clone(key.Resource),
-		Namespace: strings.Clone(key.Namespace),
+		Cluster:   reflectutil.InternString(key.Cluster),
+		Group:     reflectutil.InternString(key.Group),
+		Resource:  reflectutil.InternString(key.Resource),
+		Namespace: reflectutil.InternString(key.Namespace),
 		Name:      strings.Clone(key.Name),
 	}
 }
@@ -84,7 +86,7 @@ type VersionedKey struct {
 func (key VersionedKey) Clone() VersionedKey {
 	return VersionedKey{
 		Key:     key.Key.Clone(),
-		Version: strings.Clone(key.Version),
+		Version: reflectutil.InternString(key.Version),
 	}
 }
 

--- a/pkg/util/reflect/reflect.go
+++ b/pkg/util/reflect/reflect.go
@@ -14,7 +14,10 @@
 
 package reflectutil
 
-import "reflect"
+import (
+	"reflect"
+	"unique"
+)
 
 func TypeOf[T any]() reflect.Type {
 	array := [0]T{}
@@ -25,3 +28,7 @@ func TypeOf[T any]() reflect.Type {
 func ZeroOf[T any]() (_ T) { return }
 
 func Identity[T any](t T) T { return t }
+
+func InternString(s string) string {
+	return unique.Make(s).Value()
+}


### PR DESCRIPTION
### Description

<!-- What does this PR do? -->
Intern strings instead of just deep-cloning them to reduce memory usage.

- unique package uses a WeakMap, so there is no memory leak
- Only highly repetitive strings are interned. Non-event object names and resource versions rarely repeat, so they are not interned.
- unique package handles string cloning internally, so we don't need to do it again.

### Related issues

<!--
If this PR fixes existing issues, reference them here, e.g.:

- Closes #1

It is not necessary to create an issue before creating a PR.
-->

### Special notes for your reviewer:

<!-- if any -->
